### PR TITLE
Fix hero alignment and enlarge employment hero

### DIFF
--- a/employment.html
+++ b/employment.html
@@ -40,13 +40,13 @@
     </div>
   </nav>
 
-  <header class="relative isolate bg-black flex items-center min-h-screen">
+  <header class="relative isolate bg-black flex items-center justify-center overflow-hidden min-h-screen">
     <img src="assets/hero.jpg" alt="Scrap metal piles ready for recycling"
          class="absolute inset-0 -z-10 h-full w-full object-cover opacity-60" />
     <div class="absolute inset-0 -z-10 bg-black/70"></div>
 
-    <div class="mx-auto max-w-3xl py-32 px-6 text-center text-white lg:px-8">
-      <h1 class="text-4xl font-bold">Employment Opportunities</h1>
+    <div class="mx-auto max-w-3xl px-6 text-center text-white lg:px-8">
+      <h1 class="text-5xl sm:text-6xl font-bold">Employment Opportunities</h1>
     </div>
   </header>
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
   </nav>
   <main class="flex-grow pt-20">
   <!-- ========== HERO ========== -->
-  <header id="home" class="relative isolate bg-black flex items-center min-h-screen">
+  <header id="home" class="relative isolate bg-black flex items-center justify-center overflow-hidden min-h-screen">
     <img src="assets/hero.jpg" alt="Scrap metal piles ready for recycling"
          class="absolute inset-0 -z-10 h-full w-full object-cover opacity-60" />
     <div class="absolute inset-0 -z-10 bg-black/70"></div>


### PR DESCRIPTION
## Summary
- center hero content horizontally across pages
- enlarge employment hero heading and center it vertically

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_685c62c77b68832981d232d4f95d453b