### PR TITLE
Adjust card layout for responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
         </p>
       </div>
 
-      <div class="mt-16 grid gap-12 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="mt-16 grid gap-12 lg:grid-cols-3">
         <div class="flex flex-col items-center text-center rounded-lg bg-gray-50 p-6 shadow border border-gray-200">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-12 w-12 text-brand-500" viewBox="0 0 24 24" fill="currentColor">
             <path d="M12 7.5a2.25 2.25 0 1 0 0 4.5 2.25 2.25 0 0 0 0-4.5Z"/>


### PR DESCRIPTION
## Summary
- keep `Why Choose Recycle WV?` cards at one column on small screens
- keep three-column layout for large screens

## Testing
- `grep -n "lg:grid-cols-3" index.html`

------
https://chatgpt.com/codex/tasks/task_e_685c63a9a9a88329be10129928ddb899