### PR TITLE
Remove hero from employment page

### DIFF
--- a/employment.html
+++ b/employment.html
@@ -40,17 +40,9 @@
     </div>
   </nav>
 
-  <header class="relative isolate bg-black flex items-center justify-center overflow-hidden min-h-screen">
-    <img src="assets/hero.jpg" alt="Scrap metal piles ready for recycling"
-         class="absolute inset-0 -z-10 h-full w-full object-cover opacity-60" />
-    <div class="absolute inset-0 -z-10 bg-black/70"></div>
-
-    <div class="mx-auto max-w-3xl px-6 text-center text-white lg:px-8">
-      <h1 class="text-5xl sm:text-6xl font-bold">Employment Opportunities</h1>
-    </div>
-  </header>
 
   <main class="mx-auto max-w-3xl p-6 flex-grow pt-20">
+    <h1 class="text-3xl font-bold sm:text-4xl mb-6">Employment Opportunities</h1>
     <p class="mb-4">Recycle WV is always looking for dedicated team members. If you're interested in joining us, please send your resume to <a href="mailto:jobs@recyclewv.com" class="text-brand-600 underline transition-colors hover:text-brand-700">jobs@recyclewv.com</a>.</p>
 
     <div class="my-8 flex flex-col gap-4">


### PR DESCRIPTION
## Summary
- delete the hero banner from `employment.html`
- keep the page heading inside the main content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c6474b9a083298346de7593a51ea6