### PR TITLE
Add Employment page header

### DIFF
--- a/employment.html
+++ b/employment.html
@@ -51,6 +51,7 @@
   </header>
 
   <main class="mx-auto max-w-3xl p-6 flex-grow pt-20">
+    <h2 class="text-3xl font-bold sm:text-4xl text-center mb-4">Employment Opportunities</h2>
     <p class="mb-4">Recycle WV is always looking for dedicated team members. If you're interested in joining us, please send your resume to <a href="mailto:jobs@recyclewv.com" class="text-brand-600 underline transition-colors hover:text-brand-700">jobs@recyclewv.com</a>.</p>
 
     <div class="my-8 flex flex-col gap-4">


### PR DESCRIPTION
## Summary
- add Employment Opportunities heading at the top of employment page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c64c4dbb4832991372e09c63ed3d5