### PR TITLE
Remove dropdown menu

### DIFF
--- a/common.js
+++ b/common.js
@@ -32,6 +32,3 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 });
 
-function toggleDropdown() {
-  document.getElementById("dropdownMenu").classList.toggle("hidden");
-}

--- a/employment.html
+++ b/employment.html
@@ -11,7 +11,7 @@
 <body class="font-sans antialiased text-black scroll-smooth flex flex-col min-h-screen overflow-x-hidden">
   <nav style="position:fixed;top:0;z-index:20;width:100%;" class="bg-white flex w-full items-center justify-between px-6 py-4 lg:px-8 text-black shadow">
     <a href="index.html#home" class="mr-6"><img src="assets/logo.jpg" alt="Recycle WV logo" class="h-8 w-auto" /></a>
-      <ul class="hidden md:flex gap-8 text-sm">
+      <ul class="flex flex-wrap gap-4 text-sm">
         <li><a href="index.html#services" class="transition-colors hover:text-brand-100">Services</a></li>
         <li><a href="index.html#materials" class="transition-colors hover:text-brand-100">Materials</a></li>
         <li><a href="index.html#process" class="transition-colors hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
@@ -19,24 +19,8 @@
         <li><a href="index.html#contact" class="transition-colors hover:text-brand-100">Contact</a></li>
         <li><a href="employment.html" class="transition-colors hover:text-brand-100">Employment</a></li>
       </ul>
-    <div class="ml-auto flex items-center">
+    <div class="ml-auto">
       <a href="tel:13044251788" class="inline-flex items-center gap-2 rounded-md bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 transition-colors">Call&nbsp;Now</a>
-      <div class="relative ml-4 md:hidden" id="dropdown">
-        <button onclick="toggleDropdown()" class="inline-flex items-center gap-1 text-sm font-medium hover:text-brand-600 transition-colors">
-          Menu
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.584l3.71-4.353a.75.75 0 011.14.976l-4.25 5a.75.75 0 01-1.14 0l-4.25-5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-          </svg>
-        </button>
-          <ul id="dropdownMenu" class="absolute -right-6 top-full hidden w-48 rounded-md bg-white shadow-lg">
-            <li><a href="index.html#services" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Services</a></li>
-            <li><a href="index.html#materials" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Materials</a></li>
-            <li><a href="index.html#process" class="block px-4 py-2 hover:bg-gray-100 transition-colors">How&nbsp;It&nbsp;Works</a></li>
-            <li><a href="index.html#map" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Directions</a></li>
-            <li><a href="index.html#contact" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Contact</a></li>
-            <li><a href="employment.html" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Employment</a></li>
-          </ul>
-      </div>
     </div>
   </nav>
 

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <body class="font-sans antialiased text-black scroll-smooth flex flex-col min-h-screen overflow-x-hidden">
   <nav style="position:fixed;top:0;z-index:20;width:100%;" class="bg-white flex w-full items-center justify-between px-6 py-4 lg:px-8 text-black shadow">
     <a href="index.html#home" class="mr-6"><img src="assets/logo.jpg" alt="Recycle WV logo" class="h-8 w-auto" /></a>
-      <ul class="hidden md:flex gap-8 text-sm">
+      <ul class="flex flex-wrap gap-4 text-sm">
         <li><a href="index.html#services" class="transition-colors hover:text-brand-100">Services</a></li>
         <li><a href="index.html#materials" class="transition-colors hover:text-brand-100">Materials</a></li>
         <li><a href="index.html#process" class="transition-colors hover:text-brand-100">How&nbsp;It&nbsp;Works</a></li>
@@ -20,24 +20,8 @@
         <li><a href="index.html#contact" class="transition-colors hover:text-brand-100">Contact</a></li>
         <li><a href="employment.html" class="transition-colors hover:text-brand-100">Employment</a></li>
       </ul>
-    <div class="ml-auto flex items-center">
+    <div class="ml-auto">
       <a href="tel:13044251788" class="inline-flex items-center gap-2 rounded-md bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 transition-colors">Call&nbsp;Now</a>
-      <div class="relative ml-4 md:hidden" id="dropdown">
-        <button onclick="toggleDropdown()" class="inline-flex items-center gap-1 text-sm font-medium hover:text-brand-600 transition-colors">
-          Menu
-          <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-            <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 011.06.02L10 11.584l3.71-4.353a.75.75 0 011.14.976l-4.25 5a.75.75 0 01-1.14 0l-4.25-5a.75.75 0 01.02-1.06z" clip-rule="evenodd" />
-          </svg>
-        </button>
-          <ul id="dropdownMenu" class="absolute -right-6 top-full hidden w-48 rounded-md bg-white shadow-lg">
-            <li><a href="index.html#services" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Services</a></li>
-            <li><a href="index.html#materials" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Materials</a></li>
-            <li><a href="index.html#process" class="block px-4 py-2 hover:bg-gray-100 transition-colors">How&nbsp;It&nbsp;Works</a></li>
-            <li><a href="index.html#map" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Directions</a></li>
-            <li><a href="index.html#contact" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Contact</a></li>
-            <li><a href="employment.html" class="block px-4 py-2 hover:bg-gray-100 transition-colors">Employment</a></li>
-          </ul>
-      </div>
     </div>
   </nav>
   <main class="flex-grow pt-20">


### PR DESCRIPTION
## Summary
- show navigation links on all screen sizes
- drop the mobile dropdown menu
- remove unused `toggleDropdown` function

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c66a1eda08329b7b13b3376c08c61