### PR TITLE
Move job links below contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,11 +193,6 @@
             <li><strong>Hours:</strong> Mon–Fri 8:00 AM – 4:30 PM</li>
           </ul>
 
-          <div class="mt-8 flex flex-col gap-4">
-            <a href="https://www.indeed.com/cmp/Recycle-Wv-1/jobs" target="_blank" class="inline-block rounded-md bg-brand-500 px-6 py-3 text-center font-semibold text-white hover:bg-brand-600 transition-colors">Open Positions</a>
-            <a href="assets/driver-application.pdf" download class="inline-block rounded-md border border-brand-500 px-6 py-3 text-center font-semibold text-brand-500 hover:bg-brand-50 transition-colors">Driver Application</a>
-            <a href="assets/job-application.pdf" download class="inline-block rounded-md border border-brand-500 px-6 py-3 text-center font-semibold text-brand-500 hover:bg-brand-50 transition-colors">Job Application</a>
-          </div>
 
         </div>
 
@@ -221,6 +216,11 @@
           </div>
           <p class="mt-4 text-xs text-black">We’ll never share your info.</p>
         </form>
+      </div>
+      <div class="mt-8 flex flex-col gap-4">
+        <a href="https://www.indeed.com/cmp/Recycle-Wv-1/jobs" target="_blank" class="inline-block rounded-md bg-brand-500 px-6 py-3 text-center font-semibold text-white hover:bg-brand-600 transition-colors">Open Positions</a>
+        <a href="assets/driver-application.pdf" download class="inline-block rounded-md border border-brand-500 px-6 py-3 text-center font-semibold text-brand-500 hover:bg-brand-50 transition-colors">Driver Application</a>
+        <a href="assets/job-application.pdf" download class="inline-block rounded-md border border-brand-500 px-6 py-3 text-center font-semibold text-brand-500 hover:bg-brand-50 transition-colors">Job Application</a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- reposition job application links so they appear below the contact form

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c71f845cc83299d05a9fd95b3a12b